### PR TITLE
initial prototype for setup/maintaining set of filters

### DIFF
--- a/common/shared.py
+++ b/common/shared.py
@@ -15,10 +15,9 @@ def jiraquery (options, url):
     return json.load(urllib2.urlopen(request))
 
 def jirapost(options, url, data):
-    if(options.verbose):
-        handler=urllib2.HTTPSHandler(debuglevel=1)
-    else:
-        handler=urllib2.HTTPSHandler()
+    
+    #    handler=urllib2.HTTPSHandler(debuglevel=1)
+    handler=urllib2.HTTPSHandler()
         
     opener = urllib2.build_opener(handler)
     urllib2.install_opener(opener)

--- a/common/shared.py
+++ b/common/shared.py
@@ -1,0 +1,68 @@
+import urllib
+import urllib2
+import base64
+import json
+
+def jiraquery (options, url):
+    request = urllib2.Request(options.jiraserver + url)
+    base64string = base64.encodestring('%s:%s' % (options.username, options.password)).replace('\n', '')
+    request.add_header("Authorization", "Basic %s" % base64string)   
+
+
+    if options.verbose:
+        print "Query: " + options.jiraserver + url
+   
+    return json.load(urllib2.urlopen(request))
+
+def jirapost(options, url, data):
+    handler=urllib2.HTTPSHandler(debuglevel=1)
+    opener = urllib2.build_opener(handler)
+    urllib2.install_opener(opener)
+
+    jdata = json.dumps(data)
+    
+    request = urllib2.Request(options.jiraserver + url,jdata)
+    base64string = base64.encodestring('%s:%s' % (options.username, options.password)).replace('\n', '')
+    request.add_header("Authorization", "Basic %s" % base64string)   
+    request.add_header("Content-Type","application/json")
+
+    if options.verbose:
+        print "Post: " + options.jiraserver + url
+        print "Data: " + jdata
+
+    response = ''
+    
+    try: 
+        response = urllib2.urlopen(request)
+    except urllib2.HTTPError, e:
+        print('HTTPError = ' + str(e.code) + ' ' + e.read())
+        raise(e)
+
+    return json.load(response)
+    
+def jiraupdate(options, url, data):
+    handler=urllib2.HTTPSHandler(debuglevel=1)
+    opener = urllib2.build_opener(handler)
+    urllib2.install_opener(opener)
+
+    jdata = json.dumps(data)
+    
+    request = urllib2.Request(options.jiraserver + url,jdata)
+    base64string = base64.encodestring('%s:%s' % (options.username, options.password)).replace('\n', '')
+    request.add_header("Authorization", "Basic %s" % base64string)   
+    request.add_header("Content-Type","application/json")
+    request.get_method = lambda: 'PUT'
+    
+    if options.verbose:
+        print "Post: " + options.jiraserver + url
+        print "Data: " + jdata
+
+    response = ''
+    
+    try: 
+        response = urllib2.urlopen(request)
+    except urllib2.HTTPError, e:
+        print('HTTPError = ' + str(e.code) + ' ' + e.read())
+        raise(e)
+
+    return json.load(response)

--- a/common/shared.py
+++ b/common/shared.py
@@ -15,7 +15,11 @@ def jiraquery (options, url):
     return json.load(urllib2.urlopen(request))
 
 def jirapost(options, url, data):
-    handler=urllib2.HTTPSHandler(debuglevel=1)
+    if(options.verbose):
+        handler=urllib2.HTTPSHandler(debuglevel=1)
+    else:
+        handler=urllib2.HTTPSHandler()
+        
     opener = urllib2.build_opener(handler)
     urllib2.install_opener(opener)
 
@@ -41,7 +45,11 @@ def jirapost(options, url, data):
     return json.load(response)
     
 def jiraupdate(options, url, data):
-    handler=urllib2.HTTPSHandler(debuglevel=1)
+    if(options.verbose):
+        handler=urllib2.HTTPSHandler(debuglevel=1)
+    else:
+        handler=urllib2.HTTPSHandler()
+        
     opener = urllib2.build_opener(handler)
     urllib2.install_opener(opener)
 

--- a/constants.json
+++ b/constants.json
@@ -9,34 +9,49 @@
 	"project": "JBDS",
 	"pattern": "9.0.(?!x).*"
 	},
-   "jbide_maint_versions": {
+    "jbide_maint_versions": {
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": "4.2.(?!x).*"
 	},
+    "jbide_next_versions": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.(2|3).(?!x).*",
+        "released": false,
+        "hasStartDate": true
+    },
     "jbds_maint_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "8...(?!x).*"
 	},
-   "jbide_next_version": {
-	"function": "listVersions",
-	"project": "JBIDE",
-	"pattern": "4.2.2.Final|4.3.0.Alpha1"
-    },
-    "jbds_next_version": {
+    "jbds_next_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
-	"pattern": "8.0.2.*|9.0.0.Alpha1"
+	"pattern": "(8|9)...(?!x)|",
+	"released": false,
+	"hasStartDate": true
     },
-    "jbide_lockdown_version": {
+    
+    "jbide_freeze_versions": {
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": "4.2.1.*"
     },
-    "jbds_lockdown_version": {
+    "jbds_freeze_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "8.0.1.*"
+    },
+    "jbds_bucket_version": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": ".*.x|LATER"
+    },
+    "jbide_bucket_version": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": ".*.x$|LATER"
     }
 }

--- a/constants.json
+++ b/constants.json
@@ -33,12 +33,12 @@
 	"released": false,
 	"hasStartDate": true
     },
-    "jbds_bucket_version": {
+    "jbds_bucket_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": ".*.x|LATER"
     },
-    "jbide_bucket_version": {
+    "jbide_bucket_versions": {
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": ".*.x$|LATER"

--- a/constants.json
+++ b/constants.json
@@ -19,24 +19,24 @@
 	"project": "JBDS",
 	"pattern": "8...(?!x).*"
 	},
-   "jbide_lockdown_version": {
+   "jbide_next_version": {
 	"function": "listVersions",
 	"project": "JBIDE",
-	"pattern": "4.2.1.Final"
+	"pattern": "4.2.2.Final|4.3.0.Alpha1"
+    },
+    "jbds_next_version": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "8.0.2.*|9.0.0.Alpha1"
+    },
+    "jbide_lockdown_version": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.2.1.*"
     },
     "jbds_lockdown_version": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "8.0.1.*"
-    },
-    "jbide_next_version": {
-	"function": "listVersions",
-	"project": "JBIDE",
-	"pattern": "4.3.0.Alpha1"
-    },
-    "jbds_lockdown_version": {
-	"function": "listVersions",
-	"project": "JBDS",
-	"pattern": "9.0.0.Alpha1"
     }
 }

--- a/constants.json
+++ b/constants.json
@@ -1,0 +1,22 @@
+{
+    "jbide_master_versions": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.2.(?!x).*"
+	},
+    "jbds_master_versions": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "9.0.(?!x).*"
+	},
+    "jbide_lockdown_version": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.2.1.Final"
+    },
+    "jbds_lockdown_version": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "8.0.1.*"
+    }
+}

--- a/constants.json
+++ b/constants.json
@@ -7,12 +7,17 @@
     "jbds_master_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
-	"pattern": "9.0.(?!x).*"
+	"pattern": "9...(?!x).*"
 	},
     "jbide_maint_versions": {
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": "4.2.(?!x).*"
+	},
+    "jbds_maint_versions": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "8...(?!x).*"
 	},
     "jbide_next_versions": {
 	"function": "listVersions",
@@ -21,28 +26,12 @@
         "released": false,
         "hasStartDate": true
     },
-    "jbds_maint_versions": {
-	"function": "listVersions",
-	"project": "JBDS",
-	"pattern": "8...(?!x).*"
-	},
     "jbds_next_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "(8|9)...(?!x)|",
 	"released": false,
 	"hasStartDate": true
-    },
-    
-    "jbide_freeze_versions": {
-	"function": "listVersions",
-	"project": "JBIDE",
-	"pattern": "4.2.1.*"
-    },
-    "jbds_freeze_versions": {
-	"function": "listVersions",
-	"project": "JBDS",
-	"pattern": "8.0.1.*"
     },
     "jbds_bucket_version": {
 	"function": "listVersions",
@@ -53,5 +42,17 @@
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": ".*.x$|LATER"
+    },
+    "jbide_freeze_versions": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.2.1.*",
+	"codefrozen": true
+    },
+    "jbds_freeze_versions": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "8.0.1.*",
+	"codefrozen": true
     }
 }

--- a/constants.json
+++ b/constants.json
@@ -2,14 +2,24 @@
     "jbide_master_versions": {
 	"function": "listVersions",
 	"project": "JBIDE",
-	"pattern": "4.2.(?!x).*"
+	"pattern": "4.3.(?!x).*"
 	},
     "jbds_master_versions": {
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "9.0.(?!x).*"
 	},
-    "jbide_lockdown_version": {
+   "jbide_maint_versions": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.2.(?!x).*"
+	},
+    "jbds_maint_versions": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "8...(?!x).*"
+	},
+   "jbide_lockdown_version": {
 	"function": "listVersions",
 	"project": "JBIDE",
 	"pattern": "4.2.1.Final"
@@ -18,5 +28,15 @@
 	"function": "listVersions",
 	"project": "JBDS",
 	"pattern": "8.0.1.*"
+    },
+    "jbide_next_version": {
+	"function": "listVersions",
+	"project": "JBIDE",
+	"pattern": "4.3.0.Alpha1"
+    },
+    "jbds_lockdown_version": {
+	"function": "listVersions",
+	"project": "JBDS",
+	"pattern": "9.0.0.Alpha1"
     }
 }

--- a/filters-composite.json
+++ b/filters-composite.json
@@ -1,0 +1,12 @@
+{
+    "ds_my_lockdown": {
+        "description": "Issues are New and have no target release set", 
+        "id": "12323032", 
+        "jql": "filter='ds_mystuff' and filter='ds_lockdown'"
+    }, 
+    "ds_my_next": {
+        "description": "Issues are New and have no target release set", 
+        "id": "12323022", 
+        "jql": "filter='ds_mystuff' and filter='ds_next'"
+    }
+}

--- a/filters-composite.json
+++ b/filters-composite.json
@@ -1,12 +1,22 @@
 {
-    "ds_my_lockdown": {
-        "description": "Issues are New and have no target release set", 
-        "id": "12323032", 
-        "jql": "filter='ds_mystuff' and filter='ds_lockdown'"
+    "ds_my_freeze": {
+        "description": "Issues assigned or lead by user that is marked for freeze", 
+        "id": "12323043", 
+        "jql": "filter='ds_mystuff' and filter='ds_freeze' and filter='ds_unresolved'"
+    }, 
+    "ds_my_latertriage": {
+        "description": "Stuff in .x or LATER buckets", 
+        "id": "12323035", 
+        "jql": "filter='ds_mystuff' and filter='ds_unresolved' and (project = 'JBIDE' and fixversion in ( %(jbide_bucket_version)s ) or (project = 'JBDS' and fixversion in ( %(jbds_bucket_version)s )))"
+    }, 
+    "ds_my_needtriage": {
+        "description": "Non triaged stuff that I'm assigned or leading", 
+        "id": "12323034", 
+        "jql": "filter='ds_mystuff' and fixVersion is empty and filter='ds_unresolved'"
     }, 
     "ds_my_next": {
-        "description": "Issues are New and have no target release set", 
+        "description": "Upcoming work for next version", 
         "id": "12323022", 
-        "jql": "filter='ds_mystuff' and filter='ds_next'"
+        "jql": "filter='ds_mystuff' and filter='ds_next' and filter='ds_unresolved'"
     }
 }

--- a/filters-composite.json
+++ b/filters-composite.json
@@ -7,7 +7,7 @@
     "ds_my_latertriage": {
         "description": "Stuff in .x or LATER buckets", 
         "id": "12323035", 
-        "jql": "filter='ds_mystuff' and filter='ds_unresolved' and (project = 'JBIDE' and fixversion in ( %(jbide_bucket_version)s ) or (project = 'JBDS' and fixversion in ( %(jbds_bucket_version)s )))"
+        "jql": "filter='ds_mystuff' and filter='ds_unresolved' and (project = 'JBIDE' and fixversion in ( %(jbide_bucket_versions)s ) or (project = 'JBDS' and fixversion in ( %(jbds_bucket_versions)s )))"
     }, 
     "ds_my_needtriage": {
         "description": "Non triaged stuff that I'm assigned or leading", 

--- a/filters.json
+++ b/filters.json
@@ -15,7 +15,7 @@
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_freeze_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_freeze_versions)s )))"
     }, 
     "ds_maint": {
-        "description": "Current project+versions for JBIDE/JBDS maintainence", 
+        "description": "Current project+versions for JBIDE/JBDS maintenance", 
         "id": "12323017", 
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_maint_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_maint_versions)s )))"
     }, 
@@ -35,9 +35,9 @@
         "jql": "'Target Release' is not EMPTY AND 'CDW pm_ack' = '?' AND resolution = Unresolved"
     }, 
     "ds_next": {
-        "description": "Issues for next development in either maintanence or master", 
+        "description": "Issues for next development in either maintenance or master", 
         "id": "12323033", 
-        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_next_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_next_versions)s )))"
+        "jql": "((project = JBIDE AND fixVersion in (  %(jbide_next_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_next_versions)s )))"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -10,12 +10,12 @@
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_lockdown_version)s )) OR (project = JBDS AND fixVersion in ( %(jbds_lockdown_version)s )))"
     }, 
     "ds_maint": {
-        "description": "Current project+versions for devstudio maintanence", 
+        "description": "Current project+versions for JBIDE/JBDS maintainence", 
         "id": "12323017", 
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_maint_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_maint_versions)s )))"
     }, 
     "ds_master": {
-        "description": "Current project+versions for devstudio stream. (JBIDE-4.3.*, JBDS-9.*)", 
+        "description": "Current project+versions for JBIDE/JBDS master stream", 
         "id": "12323021", 
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_master_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_master_versions)s )))"
     }, 

--- a/filters.json
+++ b/filters.json
@@ -14,6 +14,21 @@
         "id": "12323031", 
         "jql": "((project = JBIDE AND fixVersion in ( %(jbide_freeze_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_freeze_versions)s )))"
     }, 
+    "ds_lint_illegalfixversion": {
+        "description": "illegal fix versions", 
+        "id": "12323048", 
+        "jql": "(project = JBIDE AND (fixVersion in ( %(jbide_bucket_versions)s ) OR fixVersion is EMPTY) OR project = JBDS AND (fixVersion in ( %(jbds_bucket_versions)s ) OR fixVersion is EMPTY)) AND resolution = done"
+    }, 
+    "ds_lint_nocomponent": {
+        "description": "Unresolved issues without components", 
+        "id": "12323047", 
+        "jql": "project in (JBIDE,JBDS) and component is EMPTY AND resolution is EMPTY"
+    }, 
+    "ds_lint_unresolved_in_release": {
+        "description": "Unresolved issues in already released versions", 
+        "id": "12323049", 
+        "jql": "project in (JBIDE, JBDS) and fixVersion in releasedVersions() and resolution is empty"
+    }, 
     "ds_maint": {
         "description": "Current project+versions for JBIDE/JBDS maintenance", 
         "id": "12323017", 

--- a/filters.json
+++ b/filters.json
@@ -7,7 +7,12 @@
     "ds_maint": {
         "description": "Current project+versions for devstudio maintanence", 
         "id": "12323017", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final', '4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.GA', '8.0.2.GA', '8.0.3.GA')))"
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final', '4.2.1.Final', '4.2.2.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.GA', '8.0.1.GA', '8.0.2.GA', '8.0.3.GA')))"
+    }, 
+    "ds_my_next": {
+        "description": "My stuff in next major", 
+        "id": "12323022", 
+        "jql": "filter='ds_mystuff' and filter='ds_next'"
     }, 
     "ds_mystuff": {
         "description": "Issues assigned to current user or in a component lead by current user.", 
@@ -22,7 +27,7 @@
     "ds_next": {
         "description": "Current project+versions for next devstudio.", 
         "id": "12323021", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.3.0.Alpha1')) OR (project = JBDS AND fixVersion in ('9.0.0.Alpha1')))"
+        "jql": "((project = JBIDE AND fixVersion > '4.3.0.Alpha1' and fixVersion <= '4.3.0.Final') OR (project = JBDS AND fixVersion > '9.0.0.Alpha1' and fixVersion <= '9.0.0.GA'))"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -2,26 +2,22 @@
     "ds_cdwtriage": {
         "description": "Issues are New and have no target release set", 
         "id": "12323016", 
-        "jql": "project = JBDS AND status = New AND (\"Target Release\" is EMPTY OR \"CDW release\" in (\"?\"))"
+        "jql": "project = JBDS AND status = New AND ('Target Release' is EMPTY OR 'CDW release' in ('?'))"
     }, 
     "ds_lockdown": {
         "description": "Issues for next lockdown", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.1.GA'))"
+        "id": "12323031", 
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_lockdown_version)s )) OR (project = JBDS AND fixVersion in ( %(jbds_lockdown_version)s )))"
     }, 
     "ds_maint": {
         "description": "Current project+versions for devstudio maintanence", 
         "id": "12323017", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final', '4.2.1.Final', '4.2.2.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.GA', '8.0.1.GA', '8.0.2.GA', '8.0.3.GA')))"
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_master_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_master_versions)s )))"
     }, 
     "ds_master": {
         "description": "Current project+versions for devstudio stream. (JBIDE-4.3.*, JBDS-9.*)", 
         "id": "12323021", 
         "jql": "((project = JBIDE AND fixVersion > '4.3.0.Alpha1' and fixVersion <= '4.3.0.Final') OR (project = JBDS AND fixVersion > '9.0.0.Alpha1' and fixVersion <= '9.0.0.GA'))"
-    }, 
-    "ds_my_next": {
-        "description": "My stuff in next major", 
-        "id": "12323022", 
-        "jql": "filter='ds_mystuff' and filter='ds_next'"
     }, 
     "ds_mystuff": {
         "description": "Issues assigned to current user or in a component lead by current user.", 
@@ -31,12 +27,7 @@
     "ds_needpmack": {
         "description": "Product manager have not yet approved a jira with a target release", 
         "id": "12323018", 
-        "jql": "\"Target Release\" is not EMPTY AND \"CDW pm_ack\" = \"?\" AND resolution = Unresolved"
-    }, 
-    "ds_next": {
-        "description": "Next upcoming versions", 
-        "id": "12323021", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.2.Final', '4.3.0.Alpha1')) OR (project = JBDS AND fixVersion in ('8.0.2.GA', '9.0.0.Alpha1'))"
+        "jql": "'Target Release' is not EMPTY AND 'CDW pm_ack' = '?' AND resolution = Unresolved"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -4,10 +4,19 @@
         "id": "12323016", 
         "jql": "project = JBDS AND status = New AND (\"Target Release\" is EMPTY OR \"CDW release\" in (\"?\"))"
     }, 
+    "ds_lockdown": {
+        "description": "Issues for next lockdown", 
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.1.GA'))"
+    }, 
     "ds_maint": {
         "description": "Current project+versions for devstudio maintanence", 
         "id": "12323017", 
         "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final', '4.2.1.Final', '4.2.2.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.GA', '8.0.1.GA', '8.0.2.GA', '8.0.3.GA')))"
+    }, 
+    "ds_master": {
+        "description": "Current project+versions for devstudio stream. (JBIDE-4.3.*, JBDS-9.*)", 
+        "id": "12323021", 
+        "jql": "((project = JBIDE AND fixVersion > '4.3.0.Alpha1' and fixVersion <= '4.3.0.Final') OR (project = JBDS AND fixVersion > '9.0.0.Alpha1' and fixVersion <= '9.0.0.GA'))"
     }, 
     "ds_my_next": {
         "description": "My stuff in next major", 
@@ -25,9 +34,9 @@
         "jql": "\"Target Release\" is not EMPTY AND \"CDW pm_ack\" = \"?\" AND resolution = Unresolved"
     }, 
     "ds_next": {
-        "description": "Current project+versions for next devstudio.", 
+        "description": "Next upcoming versions", 
         "id": "12323021", 
-        "jql": "((project = JBIDE AND fixVersion > '4.3.0.Alpha1' and fixVersion <= '4.3.0.Final') OR (project = JBDS AND fixVersion > '9.0.0.Alpha1' and fixVersion <= '9.0.0.GA'))"
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.2.Final', '4.3.0.Alpha1')) OR (project = JBDS AND fixVersion in ('8.0.2.GA', '9.0.0.Alpha1'))"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -1,10 +1,32 @@
 {
-    "devstudio_next": {
-        "description": "Current project+versions for next devstudio.", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.1.Final')))"
+    "ds_cdwtriage": {
+        "description": "Issues are New and have no target release set", 
+        "id": "12323016", 
+        "jql": "project = JBDS AND status = New AND (\"Target Release\" is EMPTY OR \"CDW release\" in (\"?\"))"
     }, 
-    "devstudio_stable": {
+    "ds_maint": {
         "description": "Current project+versions for devstudio maintanence", 
-        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.Final')))"
+        "id": "12323017", 
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final', '4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.GA', '8.0.2.GA', '8.0.3.GA')))"
+    }, 
+    "ds_mystuff": {
+        "description": "Issues assigned to current user or in a component lead by current user.", 
+        "id": "12323019", 
+        "jql": "assignee = currentUser() or component in (componentsLeadByUser())"
+    }, 
+    "ds_needpmack": {
+        "description": "Product manager have not yet approved a jira with a target release", 
+        "id": "12323018", 
+        "jql": "\"Target Release\" is not EMPTY AND \"CDW pm_ack\" = \"?\" AND resolution = Unresolved"
+    }, 
+    "ds_next": {
+        "description": "Current project+versions for next devstudio.", 
+        "id": "12323021", 
+        "jql": "((project = JBIDE AND fixVersion in ('4.3.0.Alpha1')) OR (project = JBDS AND fixVersion in ('9.0.0.Alpha1')))"
+    }, 
+    "ds_unresolved": {
+        "description": "Issues that are unresolved", 
+        "id": "12323020", 
+        "jql": "resolution is EMPTY"
     }
 }

--- a/filters.json
+++ b/filters.json
@@ -4,10 +4,15 @@
         "id": "12323016", 
         "jql": "project = JBDS AND status = New AND ('Target Release' is EMPTY OR 'CDW release' in ('?'))"
     }, 
-    "ds_lockdown": {
-        "description": "Issues for next lockdown", 
+    "ds_decision": {
+        "description": "Issues that has has reference to a DECISION (experimental)", 
+        "id": "12323042", 
+        "jql": "comment ~ DECISION"
+    }, 
+    "ds_freeze": {
+        "description": "Issues for next freeze", 
         "id": "12323031", 
-        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_lockdown_version)s )) OR (project = JBDS AND fixVersion in ( %(jbds_lockdown_version)s )))"
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_freeze_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_freeze_versions)s )))"
     }, 
     "ds_maint": {
         "description": "Current project+versions for JBIDE/JBDS maintainence", 
@@ -30,9 +35,9 @@
         "jql": "'Target Release' is not EMPTY AND 'CDW pm_ack' = '?' AND resolution = Unresolved"
     }, 
     "ds_next": {
-        "description": "Issues for next development", 
+        "description": "Issues for next development in either maintanence or master", 
         "id": "12323033", 
-        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_next_version)s )) OR (project = JBDS AND fixVersion in ( %(jbds_lockdown_version)s )))"
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_next_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_next_versions)s )))"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -12,12 +12,12 @@
     "ds_maint": {
         "description": "Current project+versions for devstudio maintanence", 
         "id": "12323017", 
-        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_master_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_master_versions)s )))"
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_maint_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_maint_versions)s )))"
     }, 
     "ds_master": {
         "description": "Current project+versions for devstudio stream. (JBIDE-4.3.*, JBDS-9.*)", 
         "id": "12323021", 
-        "jql": "((project = JBIDE AND fixVersion > '4.3.0.Alpha1' and fixVersion <= '4.3.0.Final') OR (project = JBDS AND fixVersion > '9.0.0.Alpha1' and fixVersion <= '9.0.0.GA'))"
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_master_versions)s )) OR (project = JBDS AND fixVersion in ( %(jbds_master_versions)s )))"
     }, 
     "ds_mystuff": {
         "description": "Issues assigned to current user or in a component lead by current user.", 
@@ -28,6 +28,11 @@
         "description": "Product manager have not yet approved a jira with a target release", 
         "id": "12323018", 
         "jql": "'Target Release' is not EMPTY AND 'CDW pm_ack' = '?' AND resolution = Unresolved"
+    }, 
+    "ds_next": {
+        "description": "Issues for next development", 
+        "id": "12323033", 
+        "jql": "((project = JBIDE AND fixVersion in ( %(jbide_next_version)s )) OR (project = JBDS AND fixVersion in ( %(jbds_lockdown_version)s )))"
     }, 
     "ds_unresolved": {
         "description": "Issues that are unresolved", 

--- a/filters.json
+++ b/filters.json
@@ -1,0 +1,10 @@
+{
+    "devstudio_next": {
+        "description": "Current project+versions for next devstudio.", 
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.1.Final')) OR (project = JBDS AND fixVersion in ('8.0.1.Final')))"
+    }, 
+    "devstudio_stable": {
+        "description": "Current project+versions for devstudio maintanence", 
+        "jql": "((project = JBIDE AND fixVersion in ('4.2.0.Final')) OR (project = JBDS AND fixVersion in ('8.0.0.Final')))"
+    }
+}

--- a/reports-daily.json
+++ b/reports-daily.json
@@ -1,13 +1,13 @@
 [
   {
     "Illegal fix version": {
-      "jql": "(project = JBIDE AND (fixVersion in ('3.1.x', '3.2.x', '4.0.x', '4.1.x', '4.2.x', LATER) OR fixVersion is EMPTY) OR project = JBDS AND (fixVersion in ('3.0.x', '4.0.x', '6.0.x', '7.1.x', '8.0.x', LATER) OR fixVersion is EMPTY)) AND resolution = done AND updatedDate >= -365d",
+      "jql": "(filter='ds_lint_illegalfixversion') AND updatedDate >= -720d",
       "description": "please set a valid fix version for this resolved/closed issue - cannot be blank, LATER, or #.#.x. See http://bit.ly/aTUeGq for help. "
     }
   },
   {
     "No component": {
-      "jql": "project in (JBIDE,JBDS) AND component is EMPTY AND resolution is EMPTY",
+      "jql": "filter='ds_lint_nocomponent'",
       "description": "please assign this issue to one or more components."
     }
   }

--- a/reports-weekly.json
+++ b/reports-weekly.json
@@ -1,7 +1,7 @@
 [
   {
     "Illegal fix version for resolved issue": {
-      "jql": "(project = JBIDE AND (fixVersion in ('3.1.x', '3.2.x', '4.0.x', '4.1.x', '4.2.x', LATER) OR fixVersion is EMPTY) OR project = JBDS AND (fixVersion in ('3.0.x', '4.0.x', '6.0.x', '7.1.x', '8.0.x', LATER) OR fixVersion is EMPTY)) AND resolution = done AND updatedDate >= -720d",
+      "jql": "(filter='ds_lint_illegalfixversion') AND updatedDate >= -720d",
       "description": "please set a valid fix version for this resolved/closed issue - cannot be blank, LATER, or #.#.x. See http://bit.ly/aTUeGq for help. "
     }
   },
@@ -13,13 +13,13 @@
   },
   {
     "No component": {
-      "jql": "project in (JBIDE,JBDS) AND component is EMPTY AND resolution is EMPTY",
+      "jql": "(filter='ds_lint_nocomponent')",
       "description": "please ensure this issue has a proper component set."
     }
   },
   {
     "Unresolved issue with already released fix version": {
-      "jql": "project in (JBIDE, JBDS) and fixVersion in releasedVersions() and resolution is empty",
+      "jql": "filter = 'ds_lint_unresolved_in_release'",
       "description": "This issue is set to be fixed in an already released version. Please triage."
     }
   }

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -1,12 +1,29 @@
 from optparse import OptionParser
-from common import shared 
+from common import shared
+import re
 import json
+import sys
 
 def saveFilters(name, filters):
     with open(name,'w') as outfile:
         json.dump(filters, outfile,indent=4, sort_keys=True)
 
-        
+
+def listVersions(project, pattern):
+    versions = shared.jiraquery(options,"/rest/api/latest/project/" + project + "/versions")
+    #versionmatch = re.compile('4.2.(?!x).*')
+    versionmatch = re.compile(pattern)
+    foundversions = []
+    for version in versions:
+       # print version['name']
+        if versionmatch.match(version['name']):
+            foundversions.append('"' + version['name'] + '"')
+
+    result = ", ".join(foundversions)
+
+    
+    return result
+
 usage = "usage: %prog -u <user> -p <password> -f <filters.json>\nCreate/maintain set of filters defined in filters.json."
 
 parser = OptionParser(usage)
@@ -23,9 +40,18 @@ if not options.username or not options.password:
     parser.error("Missing username or password")
 
 if options.filterfile:
-    print "Force enabling global shared filters. Will not have any effect if user is not allowed to globally share objects in jira."
-    shared.jiraupdate(options, "/rest/api/latest/filter/defaultShareScope", { 'scope': 'GLOBAL' })
+    #print "Force enabling global shared filters. Will not have any effect if user is not allowed to globally share objects in jira."
+    #shared.jiraupdate(options, "/rest/api/latest/filter/defaultShareScope", { 'scope': 'GLOBAL' })
 
+    print "Load constants"
+    constantdef = json.load(open("constants.json", 'r'))
+    constants = {}
+    for name, fields in constantdef.items():
+        method = getattr(sys.modules[__name__], fields['function'])
+        del fields['function']
+        constants[name] = method(**fields)
+        print name + "->" + constants[name]
+    
     print "Using filters defined in " + options.filterfile
     filters = json.load(open(options.filterfile, 'r'))
 
@@ -34,12 +60,12 @@ if options.filterfile:
         data = {
                 'name': name,
                 'description': fields['description'],
-                'jql': fields['jql'],
+                'jql': fields['jql'] % constants,
                 'favourite' : 'true'
         }
+        
         if 'id' in fields:
             print 'updating ' + name
-            data['name'] = data['name']
             fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
         else:
             print 'creating ' + name

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -2,6 +2,11 @@ from optparse import OptionParser
 from common import shared 
 import json
 
+def saveFilters(name, filters):
+    with open(name,'w') as outfile:
+        json.dump(filters, outfile,indent=4, sort_keys=True)
+
+        
 usage = "usage: %prog -u <user> -p <password> -f <filters.json>\nCreate/maintain set of filters defined in filters.json."
 
 parser = OptionParser(usage)
@@ -11,35 +16,40 @@ parser.add_option("-u", "--user", dest="username", help="jira username")
 parser.add_option("-p", "--pwd", dest="password", help="jira password")
 parser.add_option("-s", "--server", dest="jiraserver", default="https://issues.jboss.org", help="Jira instance")
 parser.add_option("-f", "--filters", dest="filterfile", default="filters.json", help="Filters.json")
-parser.add_option("-d", "--dry-run", dest="dryrun", action="store_true", help="do everything but actually sending mail")
-parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="dump email bodies to console")
-
+parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="more verbose logging")
 (options, args) = parser.parse_args()
 
 if not options.username or not options.password:
     parser.error("Missing username or password")
 
 if options.filterfile:
+    print "Force enabling global shared filters. Will not have any effect if user is not allowed to globally share objects in jira."
+    shared.jiraupdate(options, "/rest/api/latest/filter/defaultShareScope", { 'scope': 'GLOBAL' })
+
     print "Using filters defined in " + options.filterfile
     filters = json.load(open(options.filterfile, 'r'))
 
-    newfilters = {}
+    newfilters = filters.copy()
     for name, fields in filters.items():
         data = {
                 'name': name,
-                #'description': fields['description'],
-                'jql': fields['jql']
+                'description': fields['description'],
+                'jql': fields['jql'],
+                'favourite' : 'true'
         }
         if 'id' in fields:
             print 'updating ' + name
-            data['name'] = data['name'] + '_new'
+            data['name'] = data['name']
             fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
         else:
             print 'creating ' + name
             fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
 
         newfilters[name] = fields
-            
-    with open('filters.json','w') as outfile:
-        json.dump(newfilters, outfile,indent=4, sort_keys=True)
-        
+        saveFilters(options.filterfile + ".backup", newfilters)
+
+    saveFilters(options.filterfile, newfilters)
+    
+
+
+

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -1,0 +1,45 @@
+from optparse import OptionParser
+from common import shared 
+import json
+
+usage = "usage: %prog -u <user> -p <password> -f <filters.json>\nCreate/maintain set of filters defined in filters.json."
+
+parser = OptionParser(usage)
+
+#todo: move the shared options to common ?
+parser.add_option("-u", "--user", dest="username", help="jira username")
+parser.add_option("-p", "--pwd", dest="password", help="jira password")
+parser.add_option("-s", "--server", dest="jiraserver", default="https://issues.jboss.org", help="Jira instance")
+parser.add_option("-f", "--filters", dest="filterfile", default="filters.json", help="Filters.json")
+parser.add_option("-d", "--dry-run", dest="dryrun", action="store_true", help="do everything but actually sending mail")
+parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="dump email bodies to console")
+
+(options, args) = parser.parse_args()
+
+if not options.username or not options.password:
+    parser.error("Missing username or password")
+
+if options.filterfile:
+    print "Using filters defined in " + options.filterfile
+    filters = json.load(open(options.filterfile, 'r'))
+
+    newfilters = {}
+    for name, fields in filters.items():
+        data = {
+                'name': name,
+                #'description': fields['description'],
+                'jql': fields['jql']
+        }
+        if 'id' in fields:
+            print 'updating ' + name
+            data['name'] = data['name'] + '_new'
+            fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
+        else:
+            print 'creating ' + name
+            fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
+
+        newfilters[name] = fields
+            
+    with open('filters.json','w') as outfile:
+        json.dump(newfilters, outfile,indent=4, sort_keys=True)
+        

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -60,7 +60,7 @@ def listVersions(project, pattern=".*", released=None, hasReleaseDate=None, arch
     """
 
     versions = shared.jiraquery(options,"/rest/api/latest/project/" + project + "/versions")
-    print pattern
+    if options.verbose: print(pattern)
     versionmatch = re.compile(pattern)
     foundversions = []
     for version in versions:
@@ -108,7 +108,7 @@ parser.add_option("-s", "--server", dest="jiraserver", default="https://issues.j
 parser.add_option("-f", "--filters", dest="filterfiles", default="filters.json", help="comma separated list of filters to setup")
 parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="more verbose logging")
 (options, args) = parser.parse_args()
-
+    
 if not options.username or not options.password:
     parser.error("Missing username or password")
 
@@ -128,6 +128,7 @@ if options.filterfiles:
         newfilters = filters.copy()
         for name, fields in filters.items():
             try:
+                print "filter " + name
                 data = {
                     'name': name,
                     'description': fields['description'],
@@ -136,10 +137,10 @@ if options.filterfiles:
                 }
         
                 if 'id' in fields:
-                    print 'updating ' + name
+                    print 'updating filter ' + name + "->" + data['jql']
                     fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
                 else:
-                    print 'creating ' + name
+                    print 'creating filter ' + name + "->" + data['jql']
                     fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
 
                 newfilters[name] = fields

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -46,9 +46,9 @@ if options.filterfile:
             fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
 
         newfilters[name] = fields
-        saveFilters(options.filterfile + ".backup", newfilters)
+        saveFilters(options.filterfile, newfilters) # saving every succesful iteration to not loose a filter id 
 
-    saveFilters(options.filterfile, newfilters)
+#    saveFilters(options.filterfile, newfilters)
     
 
 

--- a/setup_filters.py
+++ b/setup_filters.py
@@ -1,35 +1,87 @@
 from optparse import OptionParser
 from common import shared
+import urllib2
 import re
 import json
 import sys
+import os
 
 def saveFilters(name, filters):
     with open(name,'w') as outfile:
         json.dump(filters, outfile,indent=4, sort_keys=True)
 
 def loadConstants():
-    print "Loading constants from constants.json"
-    constantdef = json.load(open("constants.json", 'r'))
     constants = {}
-    for name, fields in constantdef.items():
-        method = getattr(sys.modules[__name__], fields['function'])
-        del fields['function']
-        constants[name] = method(**fields)
-        print name + "->" + constants[name]
-
+    if os.path.isfile("constants.json"):
+        print "Loading constants from constants.json"
+        constantdef = json.load(open("constants.json", 'r'))
+        for name, fields in constantdef.items():
+            method = getattr(sys.modules[__name__], fields['function'])
+            del fields['function']
+            constants[name] = method(**fields)
+            print name + "->" + constants[name]
+    
     return constants
 
 
-def listVersions(project, pattern):
+def listVersions(project, pattern=".*", released=None, hasReleaseDate=None, archived=None, hasStartDate=None, lowerLimit=None, upperLimit=None, index=None):
+    """Return list of versions for a specific project matching a pattern and a list of optional filters.
+
+           arguments:
+            project -- the jira project key (i.e. 'JBIDE') (required)
+            pattern -- regular expression that the version name should match (i.e. '4.2.*') (default=.*)
+            released -- boolean to state if the version should be released or not. (default=None)
+            archived -- boolean to state if the version should be archived or not. (default=None)
+            hasStartDate -- boolean to state if the version should have a start date. (default=None)
+            hasReleaseDate -- boolean to state if the version should have a released date. (default=None)
+            upperLimit -- upper limit (default=None)
+            lowerLimit -- lower limit (default=None_
+            index -- integer to state which index to get (supports negative indexing too, -1=last element), if index out of range nothing is returned. (default=None)
+
+            examples:
+            listVersions("JBIDE", "4.2.*") -- versions in JBIDE starting with "4.2."
+            listVersions("JBIDE", "4.2.*", upperLimit=2) -- first two version of 4.2.*
+            listVersions("JBIDE", "4.2.*", released=False, upperLimit=2) -- first two version that are released in 4.2.*
+            listVersions("JBIDE", "4.2.*", released=False) -- non-released 4.2.* versions
+            listVersions("JBIDE", "4.2.*|4.3.*", released=False, hasReleaseDate=True) -- non-released that has release date in either 4.2 or 4.3 streams
+            listVersions("JBIDE", "4.2.*|4.3.*", released=False, hasStartDate=True) -- non-released that has start date in either 4.2 or 4.3 streams
+            listVersions("JBIDE", ".*", archived=True, hasReleaseDate=True, lowerLimit=2, lowerLimit=4)
+    """
+
     versions = shared.jiraquery(options,"/rest/api/latest/project/" + project + "/versions")
+    print pattern
     versionmatch = re.compile(pattern)
     foundversions = []
     for version in versions:
         if versionmatch.match(version['name']):
-            foundversions.append('"' + version['name'] + '"')
+            foundversions.append(version)
 
+    if released is not None:
+        foundversions = filter(lambda v: released == v['released'], foundversions)
+        
+    if hasReleaseDate is not None:
+        foundversions = filter(lambda v: 'releaseDate' in v, foundversions)
+
+    if hasStartDate is not None:
+        foundversions = filter(lambda v: 'startDate' in v, foundversions)
+
+    if archived is not None:
+        foundversions = filter(lambda v: archived == v['archived'], foundversions)
+        
+    if upperLimit or lowerLimit:
+        foundversions = foundversions[lowerLimit:upperLimit]
+
+    if index is not None:
+        try:
+            foundversions = [foundversions[index]]
+        except IndexError:
+            foundversions = []
+
+    foundversions = map(lambda v: v['name'], foundversions)
+    
     return ", ".join(foundversions)
+
+            
 
 usage = "usage: %prog -u <user> -p <password> -f <filters.json>\nCreate/maintain set of filters defined in filters.json."
 
@@ -39,41 +91,48 @@ parser = OptionParser(usage)
 parser.add_option("-u", "--user", dest="username", help="jira username")
 parser.add_option("-p", "--pwd", dest="password", help="jira password")
 parser.add_option("-s", "--server", dest="jiraserver", default="https://issues.jboss.org", help="Jira instance")
-parser.add_option("-f", "--filters", dest="filterfile", default="filters.json", help="Filters.json")
+parser.add_option("-f", "--filters", dest="filterfiles", default="filters.json", help="comma separated list of filters to setup")
 parser.add_option("-v", "--verbose", dest="verbose", action="store_true", help="more verbose logging")
 (options, args) = parser.parse_args()
 
 if not options.username or not options.password:
     parser.error("Missing username or password")
 
-if options.filterfile:
+
+if options.filterfiles:
     #print "Force enabling global shared filters. Will not have any effect if user is not allowed to globally share objects in jira."
     #shared.jiraupdate(options, "/rest/api/latest/filter/defaultShareScope", { 'scope': 'GLOBAL' })
 
     constants = loadConstants()
+
     
-    print "Using filters defined in " + options.filterfile
-    filters = json.load(open(options.filterfile, 'r'))
+    filterfiles = options.filterfiles.split(',')
+    for filterfile in filterfiles:
+        print "Processing filters found in " + filterfile
+        filters = json.load(open(filterfile, 'r'))
 
-    newfilters = filters.copy()
-    for name, fields in filters.items():
-        data = {
-                'name': name,
-                'description': fields['description'],
-                'jql': fields['jql'] % constants,
-                'favourite' : 'true'
-        }
+        newfilters = filters.copy()
+        for name, fields in filters.items():
+            try:
+                data = {
+                    'name': name,
+                    'description': fields['description'],
+                    'jql': fields['jql'] % constants,
+                    'favourite' : 'true'
+                }
         
-        if 'id' in fields:
-            print 'updating ' + name
-            fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
-        else:
-            print 'creating ' + name
-            fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
+                if 'id' in fields:
+                    print 'updating ' + name
+                    fields['id'] = shared.jiraupdate(options, "/rest/api/latest/filter/" + fields['id'], data)['id']
+                else:
+                    print 'creating ' + name
+                    fields['id'] = shared.jirapost(options, "/rest/api/latest/filter", data)['id']
 
-        newfilters[name] = fields
-        saveFilters(options.filterfile, newfilters) # saving every succesful iteration to not loose a filter id 
-
+                newfilters[name] = fields
+                saveFilters(filterfile, newfilters) # saving every succesful iteration to not loose a filter id 
+            except urllib2.HTTPError, e:
+                print "Problem with setting up filter %s with JQL = %s" % (data['name'], data['jql']);
+                
     
 
 


### PR DESCRIPTION
setup_filters.py will create (or update) filters defined in filters.py.

Run it by using the following:

```
python setup_filters.py -u $JIRA_USER -p $JIRA_PWD
```

TODO: toggle filter creation to make the filters public by default, for now they will have to be manually exposed
if the user has filters being private by default.